### PR TITLE
aggregation implemented, plus a few fixes to metadata; column names, …

### DIFF
--- a/spatialprofilingtoolbox/workflows/phenotype_proximity/computational_design.py
+++ b/spatialprofilingtoolbox/workflows/phenotype_proximity/computational_design.py
@@ -51,6 +51,10 @@ class PhenotypeProximityDesign(ComputationalDesign):
             return 'phenotype_2_phenotype_proximity_tests.csv'
 
     @staticmethod
+    def get_cell_pair_counts_table_name():
+        return 'phenotype_proximity_metrics'
+
+    @staticmethod
     def get_cell_pair_counts_table_header():
         """
         :return: A list of 2-tuples, each of which is a column name followed by
@@ -65,7 +69,7 @@ class PhenotypeProximityDesign(ComputationalDesign):
             ('target_phenotype', 'TEXT'),
             ('compartment', 'TEXT'),
             ('distance_limit_in_pixels', 'INTEGER'),
-            ('cell_pair_count_per_FOV', 'NUMERIC'),
+            ('phenotype_proximity_metric', 'NUMERIC'),
         ]
 
     def get_all_phenotype_signatures(self, by_name=False):
@@ -112,4 +116,4 @@ class PhenotypeProximityDesign(ComputationalDesign):
         :return: The name of the main numerical feature produced by the jobs.
         :rtype: str
         """
-        return 'cell pair count per FOV'
+        return 'phenotype proximity metric'

--- a/spatialprofilingtoolbox/workflows/phenotype_proximity/core.py
+++ b/spatialprofilingtoolbox/workflows/phenotype_proximity/core.py
@@ -503,7 +503,7 @@ class PhenotypeProximityCalculator:
                 ]
                 keys = '( ' + ' , '.join(keys_list) + ' )'
                 values = '( ' + ' , '.join(values_list) + ' )'
-                cmd = 'INSERT INTO cell_pair_counts ' + keys + ' VALUES ' + values +  ' ;'
+                cmd = ('INSERT INTO %s ' % self.computational_design.get_cell_pair_counts_table_name()) + keys + ' VALUES ' + values +  ' ;'
                 try:
                     manager.execute(cmd)
                 except sqlite3.OperationalError as exception:

--- a/spatialprofilingtoolbox/workflows/phenotype_proximity/integrator.py
+++ b/spatialprofilingtoolbox/workflows/phenotype_proximity/integrator.py
@@ -182,7 +182,57 @@ class PhenotypeProximityAnalysisIntegrator:
         """
         uri = join(self.output_path, self.computational_design.get_database_uri())
         connection = sqlite3.connect(uri)
-        table = pd.read_sql_query('SELECT * FROM cell_pair_counts', connection)
-        table = table.rename(columns={key:re.sub('_', ' ', key) for key in table.columns})
+        table_unaggregated = pd.read_sql_query('SELECT * FROM %s' % self.computational_design.get_cell_pair_counts_table_name(), connection)
         connection.close()
+        table = self.do_aggregation_over_different_files(table_unaggregated)
+        self.add_balance_metadata(table)
+        self.overwrite_radius_limited_counts(table)
+        table = table.rename(columns={key:re.sub('_', ' ', key) for key in table.columns})
         return table
+
+    def do_aggregation_over_different_files(self, table):
+        """
+        :param table: Table of cell pair counts.
+        :type table: pandas.DataFrame
+
+        :return table: Same table, but with main column *averaged* over cases of
+            multiple files associated with the same sample.
+        :type table: pandas.DataFrame
+        """
+        table.drop('id', 1, inplace=True)
+        table = table.groupby([
+            'sample_identifier',
+            'outcome_assignment',
+            'source_phenotype',
+            'target_phenotype',
+            'compartment',
+            'distance_limit_in_pixels',
+        ], as_index=False).agg('mean')
+        table.reset_index(inplace=True)
+        table.rename(columns={'index' : 'id'}, inplace=True)
+        return table
+
+    def add_balance_metadata(self, table):
+        """
+        :param table: Table to which to add metadata tag/column indicating the balance
+            type.
+        :type table: pandas.DataFrame
+        """
+        if self.computational_design.balanced:
+            table['balance_type'] = 'cell pair counts per slide area'
+        else:
+            table['balance_type'] = 'number of neighbor cells of target type, averaged over cells of source type'
+
+    def overwrite_radius_limited_counts(self, table):
+        """
+        :param table: Table of cell pair counts.
+        :type table: pandas.DataFrame
+        """
+        uri = join(self.output_path, self.computational_design.get_database_uri())
+        connection = sqlite3.connect(uri)
+        table.to_sql(
+            self.computational_design.get_cell_pair_counts_table_name(),
+            connection,
+            if_exists='replace',
+        )
+        connection.close()

--- a/spatialprofilingtoolbox/workflows/phenotype_proximity/job_generator.py
+++ b/spatialprofilingtoolbox/workflows/phenotype_proximity/job_generator.py
@@ -150,10 +150,10 @@ singularity exec \
             )
         )
         cursor = connection.cursor()
-        cursor.execute('DROP TABLE IF EXISTS cell_pair_counts ;')
+        cursor.execute('DROP TABLE IF EXISTS %s ;' % self.computational_design.get_cell_pair_counts_table_name())
         cmd = ' '.join([
             'CREATE TABLE',
-            'cell_pair_counts',
+            self.computational_design.get_cell_pair_counts_table_name(),
             '(',
             'id INTEGER PRIMARY KEY AUTOINCREMENT,',
             ' , '.join([


### PR DESCRIPTION
Addresses #21 .

Includes:
1. Aggregation (average) and re-export over `phenotype_proximity.db`.
2. Rename the "cell pair counts..." column to "phenotype proximity metric".
3. Add a column "balance type" indicating more explicitly what is measured, in the 2 cases balanced/unbalanced.
4. Renamed the table itself to "phenotype proximity metrics"

The main thing is the new function `do_aggregation_over_different_files`.