### PR TITLE
Add study lookup from specimen

### DIFF
--- a/spatialprofilingtoolbox/db/study_access.py
+++ b/spatialprofilingtoolbox/db/study_access.py
@@ -228,3 +228,18 @@ class StudyAccess(SimpleReadOnlyProvider):
             parameters=(study,),
         )
         return Institution(name=name)
+
+    def get_study_from_specimen(self, specimen: str) -> str:
+        query = '''
+        SELECT sc.primary_study
+        FROM specimen_collection_process scp
+        JOIN study_component sc ON sc.component_study=scp.study
+        WHERE scp.specimen=%s
+        ;
+        '''
+        study = GetSingleResult.string(
+            self.cursor,
+            query=query,
+            parameters=(specimen,),
+        )
+        return study

--- a/test/apiserver/unit_tests/test_lookup_study_from_specimen.py
+++ b/test/apiserver/unit_tests/test_lookup_study_from_specimen.py
@@ -1,0 +1,24 @@
+"""Check functionality of simple lookup of study."""
+
+import os
+
+from spatialprofilingtoolbox.db.database_connection import DBCursor
+from spatialprofilingtoolbox.db.study_access import StudyAccess
+
+def test_lookup():
+    environment = {
+        'SINGLE_CELL_DATABASE_HOST': 'spt-db-testing',
+        'SINGLE_CELL_DATABASE_USER': 'postgres',
+        'SINGLE_CELL_DATABASE_PASSWORD': 'postgres',
+        'USE_ALTERNATIVE_TESTING_DATABASE': '1',
+    }
+
+    for key, value in environment.items():
+        os.environ[key] = value
+
+    with DBCursor() as cursor:
+        study = StudyAccess(cursor).get_study_from_specimen('lesion 0_1')
+        assert study == 'Melanoma intralesional IL2'
+
+if __name__=='__main__':
+    test_lookup()


### PR DESCRIPTION
Adds a convenience accessor, find study name from specimen identifier, and a simple test for this new functionality.