### PR TITLE
hotfix cggnn scripts, streamline calls

### DIFF
--- a/build/cggnn/Dockerfile
+++ b/build/cggnn/Dockerfile
@@ -15,6 +15,7 @@ RUN python3.11 -m pip install psycopg2==2.9.6
 RUN python3.11 -m pip install adiscstudies==0.11.0
 RUN python3.11 -m pip install numba==0.57.0
 RUN python3.11 -m pip install attrs==23.1.0
+RUN python3.11 -m pip install tables
 RUN python3.11 -m pip install cg-gnn
 ARG version
 ARG service_name

--- a/pyproject.toml.unversioned
+++ b/pyproject.toml.unversioned
@@ -43,7 +43,8 @@ apiserver = [
     "secure==0.3.0"
 ]
 cggnn = [
-    "cg-gnn"
+    "cg-gnn",
+    "tables"
 ]
 db = [
     "pandas==2.0.2",
@@ -87,7 +88,8 @@ all = [
     "fastapi==0.100.0",
     "Pillow==9.5.0",
     "squidpy==1.3.0",
-    "secure==0.3.0"
+    "secure==0.3.0",
+    "tables"
 ]
 dev = [
     "autopep8",

--- a/spatialprofilingtoolbox/cggnn/extract.py
+++ b/spatialprofilingtoolbox/cggnn/extract.py
@@ -100,13 +100,13 @@ def extract_cggnn_data(
         Mapping from class integer label to human-interpretable result text.
     """
     extractor = FeatureMatrixExtractor(database_config_file=spt_db_config_location)
-    df_cell = _create_cell_df({
-        slide: data.dataframe for slide, data in extractor.extract(study=study).items()
-    })
     cohorts = extractor.extract_cohorts(study)
     df_label, label_to_result_text = _create_label_df(
         cohorts['assignments'],
         cohorts['strata'],
         strata_to_use,
     )
+    df_cell = _create_cell_df({
+        slide: extractor.extract(study=study)[slide].dataframe for slide in df_label.index
+    })
     return df_cell, df_label, label_to_result_text

--- a/spatialprofilingtoolbox/cggnn/extract.py
+++ b/spatialprofilingtoolbox/cggnn/extract.py
@@ -13,10 +13,17 @@ def _create_cell_df(dfs_by_specimen: dict[str, DataFrame]) -> DataFrame:
 
     df = concat(dfs_by_specimen.values(), axis=0)
     df.index.name = 'histological_structure'
+
+    # Convert binary int columns to boolean
+    channels = df.columns[df.columns.str.startswith('C ')]
+    phenotypes = df.columns[df.columns.str.startswith('P ')]
+    df[channels] = df[channels].astype(bool)
+    df[phenotypes] = df[phenotypes].astype(bool)
+
     # Reorder columns so it's specimen, xy, channels, and phenotypes
     column_order = ['specimen', 'pixel x', 'pixel y']
-    column_order.extend(df.columns[df.columns.str.startswith('C ')])
-    column_order.extend(df.columns[df.columns.str.startswith('P ')])
+    column_order.extend(channels)
+    column_order.extend(phenotypes)
     return df[column_order]
 
 

--- a/spatialprofilingtoolbox/cggnn/extract.py
+++ b/spatialprofilingtoolbox/cggnn/extract.py
@@ -113,9 +113,10 @@ def extract_cggnn_data(
         strata_to_use,
     )
     df_cell = _create_cell_df({
-        specimen: extractor.extract(specimen=specimen)[specimen].dataframe
+        specimen: extractor.extract(specimen=specimen, retain_structure_id=True)[specimen].dataframe
         for specimen in df_label.index
     } if (strata_to_use is not None) else {
-        specimen: data.dataframe for specimen, data in extractor.extract(study=study).items()
+        specimen: data.dataframe
+        for specimen, data in extractor.extract(study=study, retain_structure_id=True).items()
     })
     return df_cell, df_label, label_to_result_text

--- a/spatialprofilingtoolbox/cggnn/scripts/explore_classes.py
+++ b/spatialprofilingtoolbox/cggnn/scripts/explore_classes.py
@@ -28,6 +28,6 @@ def parse_arguments():
 
 if __name__ == "__main__":
     args = parse_arguments()
-    extractor = FeatureMatrixExtractor(args.spt_db_config_location)
+    extractor = FeatureMatrixExtractor(database_config_file=args.spt_db_config_location)
     strata = extractor.extract_cohorts(study=args.study)['strata']
     print(strata.to_string())

--- a/spatialprofilingtoolbox/cggnn/scripts/extract.py
+++ b/spatialprofilingtoolbox/cggnn/scripts/extract.py
@@ -1,6 +1,7 @@
 """Extract information cg-gnn needs from SPT and save to file."""
 
 from argparse import ArgumentParser
+from os import makedirs
 from os.path import join, exists
 from json import dump
 
@@ -46,17 +47,18 @@ def parse_arguments():
 
 if __name__ == "__main__":
     args = parse_arguments()
-    df_cell, df_label, label_to_result = extract_cggnn_data(
-        args.spt_db_config_location,
-        args.study,
-        args.strata,
-    )
-
-    assert isinstance(args.output_location, str)
-    dict_filename = join(args.output_location, 'label_to_results.json')
-    cells_filename = join(args.output_location, 'cells.h5')
-    labels_filename = join(args.output_location, 'labels.h5')
+    output_location: str = join(args.output_location, args.study)
+    assert isinstance(output_location, str)
+    makedirs(output_location, exist_ok=True)
+    dict_filename = join(output_location, 'label_to_results.json')
+    cells_filename = join(output_location, 'cells.h5')
+    labels_filename = join(output_location, 'labels.h5')
     if not (exists(dict_filename) and exists(cells_filename) and exists(labels_filename)):
+        df_cell, df_label, label_to_result = extract_cggnn_data(
+            args.spt_db_config_location,
+            args.study,
+            args.strata,
+        )
         df_cell.to_hdf(cells_filename, 'cells')
         df_label.to_hdf(labels_filename, 'labels')
         with open(dict_filename, 'w', encoding='utf-8') as f:

--- a/test/cggnn/unit_tests/test_extract.sh
+++ b/test/cggnn/unit_tests/test_extract.sh
@@ -2,18 +2,16 @@ spt cggnn extract \
     --spt_db_config_location ../db/.spt_db.config.container \
     --study "Melanoma intralesional IL2" \
     --output_location .
-$([ $? -eq 0 ] && [ -e "label_to_results.json" ] && [ -e "cells.h5" ] && [ -e "labels.h5" ])
+$([ $? -eq 0 ] && [ -e "Melanoma intralesional IL2/label_to_results.json" ] && [ -e "Melanoma intralesional IL2/cells.h5" ] && [ -e "Melanoma intralesional IL2/labels.h5" ])
 status="$?"
 echo "Status: $status"
 [ $status -eq 0 ] || echo "cggnn extract failed."
 
-cat label_to_results.json
-python3.11 -c 'import pandas as pd; print(pd.read_hdf("cells.h5"))'
-python3.11 -c 'import pandas as pd; print(pd.read_hdf("labels.h5"))'
+cat "Melanoma intralesional IL2/label_to_results.json"
+python3.11 -c 'import pandas as pd; print(pd.read_hdf("Melanoma intralesional IL2/cells.h5"))'
+python3.11 -c 'import pandas as pd; print(pd.read_hdf("Melanoma intralesional IL2/labels.h5"))'
 
-rm label_to_results.json
-rm cells.h5
-rm labels.h5
+rm -r "Melanoma intralesional IL2/"
 
 if [ $status -eq 0 ];
 then


### PR DESCRIPTION
While using `set cggnn explore_classes` and `extract` for the first time, I noticed a few fixes and improvements I could make.

- `explore_classes` didn't pass the config file location to the cursor correctly, resulting in an error. This is fixed.
- `extract` now organizes files it extracts related to a study into a directory with that study's name, for easy organization.
- `extract` does nothing if the files it intends to create are already created.
- `extract` is amended to only have FME pull specimens that are of the strata the user requested, instead of all specimens from a study 