### PR TITLE
Pin workflow image tag default to current SPT version

### DIFF
--- a/spatialprofilingtoolbox/workflow/scripts/configure.py
+++ b/spatialprofilingtoolbox/workflow/scripts/configure.py
@@ -22,6 +22,8 @@ from importlib.resources import as_file
 from importlib.resources import files
 from typing import cast
 
+from spatialprofilingtoolbox import __version__ as SPT_VERSION
+
 
 try:
     from jinja2 import Environment, BaseLoader
@@ -288,7 +290,7 @@ if __name__ == '__main__':
                          f'Got {config_variables["container_platform"]}')
 
     if ('image_tag' not in config_variables) or (config_variables['image_tag'] == ''):
-        config_variables['image_tag'] = 'latest'
+        config_variables['image_tag'] = SPT_VERSION
     config_variables['image'] = f'{workflow_configuration.image}:{config_variables["image_tag"]}'
 
     config_variables['current_working_directory'] = getcwd()


### PR DESCRIPTION
If I recall correctly, we had additional discussion about whether we wanted to remove the ability for the user to specify what SPT image version they wanted to use and fix it to whatever version they run SPT configure with. However, it could lead to issues where the development is happening on a bumped version that hasn't had a published image yet or vice versa, since most of the time we want to test a version before publishing an image. We'll have to carefully think about if this will break any test procedures.