### PR TITLE
Reduce memory footprint with an optimization in cache checking

### DIFF
--- a/spatialprofilingtoolbox/ondemand/fast_cache_assessor.py
+++ b/spatialprofilingtoolbox/ondemand/fast_cache_assessor.py
@@ -45,6 +45,8 @@ class FastCacheAssessor:
             else:
                 verbose=False
             up_to_date = self._cache_is_up_to_date(verbose=verbose)
+            if up_to_date:
+                break
             if verbose:
                 logger.debug('Waiting for cache to be available.')
             check_count += 1

--- a/spatialprofilingtoolbox/workflow/common/structure_centroids.py
+++ b/spatialprofilingtoolbox/workflow/common/structure_centroids.py
@@ -93,10 +93,12 @@ class StructureCentroids:
                     SELECT specimen, blob_contents FROM ondemand_studies_index osi
                     WHERE osi.blob_type='centroids';
                 ''', (study, ))
-                specimens_to_blobs = tuple(cursor.fetchall())
                 self._studies[study] = {}
-                for _, blob in specimens_to_blobs:
-                    obj = pickle.loads(blob)
+                while True:
+                    row = cursor.fetchone()
+                    if row is None:
+                        break
+                    obj = pickle.loads(row[1])
                     for key, value in obj.items():
                         if not key in self._studies:
                             self._studies[study][key] = {}


### PR DESCRIPTION
Simple change to prevent large all-at-once downloads that are unnecessary.