### PR TITLE
Adds sync-table utility and make one uploader more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.0.68
+- Adds a utility to perform targets synchronization of specific database tables with local files.
+
 # v1.0.67
 - First release of renamed package **smprofiler**.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smprofiler"
-version = "1.0.67"
+version = "1.0.68"
 authors = [
     { name = "James Mathews", email = "mathewj2@mskcc.org" }
 ]

--- a/smprofiler/db/scripts/sync_table.py
+++ b/smprofiler/db/scripts/sync_table.py
@@ -1,0 +1,77 @@
+from importlib.resources import as_file
+from importlib.resources import files
+from json import loads as json_loads
+import argparse
+
+from pandas import read_csv as pandas_read_csv
+
+from smprofiler.workflow.tabular_import.parsing.diagnosis import DiagnosisParser
+from smprofiler.db.database_connection import DBConnection
+from smprofiler.db.database_connection import get_and_validate_database_config
+from smprofiler.workflow.common.cli_arguments import add_argument
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog='smprofiler db sync-table',
+        description='Synchronize database table with a file artifact.'
+    )
+    add_argument(parser, 'database config')
+    parser.add_argument(
+        '--table-name',
+        dest='table_name',
+        choices=available_for_sync(),
+        required=True,
+    )
+    parser.add_argument(
+        '--study-json',
+        dest='study_json',
+        required=False,
+        help='The study.json file for the study (provides study name).',
+    )
+    parser.add_argument(
+        '--study-name',
+        dest='study_name',
+        required=False,
+        help='The study name (if study.json is not provided).',
+    )
+    parser.add_argument(
+        '--source-file',
+        dest='source_file',
+        required=True,
+        help='The source file to search for records to be uploaded or synced.',
+    )
+    parser.add_argument(
+        '--drop-first',
+        dest='drop_first',
+        action='store_true',
+        help='Indicates whether to drop all records in the remote table before attempting upload.',
+    )
+    return parser.parse_args()
+
+def available_for_sync() -> tuple[str, ...]:
+    return ('diagnosis',)
+
+def sync_table(table: str, study: str, database_config_file: str, source_file: str, drop_first: bool) -> None:
+    if table == 'diagnosis':
+        with as_file(files('adiscstudies').joinpath('fields.tsv')) as path:
+            fields = pandas_read_csv(path, sep='\t', na_filter=False)
+        with DBConnection(database_config_file=database_config_file, study=study) as connection:
+            DiagnosisParser(fields).parse(connection, source_file, drop_first=drop_first)
+        return
+    raise ValueError(f'Table "{table}" is not a supported sync target.')
+
+def main():
+    args = parse_args()
+    database_config_file = get_and_validate_database_config(args)
+    study_name = None
+    if args.study_json:
+        with open(args.study_json, 'rt', encoding='utf-8') as file:
+            study_name = json_loads(file.read())['Study name']
+    else:
+        study_name = args.study_name
+    sync_table(args.table_name, study_name, database_config_file, args.source_file, args.drop_first)
+
+if __name__=='__main__':
+    main()
+

--- a/smprofiler/workflow/tabular_import/parsing/diagnosis.py
+++ b/smprofiler/workflow/tabular_import/parsing/diagnosis.py
@@ -10,11 +10,25 @@ logger = colorized_logger(__name__)
 class DiagnosisParser(SourceToADIParser):
     """Source file parsing for outcome/diagnosis metadata."""
 
-    def parse(self, connection, diagnosis_file):
+    def parse(self, connection, diagnosis_file: str, drop_first: bool=False) -> None:
         cursor = connection.cursor()
-
         logger.debug('Considering %s', diagnosis_file)
         diagnoses = pd.read_csv(diagnosis_file, sep='\t', na_filter=False, dtype=str)
+        if (diagnoses.shape[0] <= 1):
+            logger.warning('Not enough diagnosis records, aborting the upload to database from source file.')
+            return
+        if drop_first:
+            cursor.execute('DELETE FROM diagnosis;')
+            connection.commit()
+        else:
+            cursor.execute('SELECT COUNT(*) FROM diagnosis;')
+            existing_count = int(tuple(cursor.fetchall())[0][0])
+            if (diagnoses.shape[0] == existing_count):
+                logger.warning(f'Found {existing_count} existing diagnosis records in remote (same as local). Did you want to use "--drop-first"? Aborting.')
+                return
+            if (existing_count > 0):
+                logger.warning(f'Found {existing_count} existing diagnosis records in remote. Did you want to use "--drop-first"? Aborting.')
+                return
         logger.info('Saving %s diagnosis records.', diagnoses.shape[0])
         for _, row in diagnoses.iterrows():
             diagnosis_record = (


### PR DESCRIPTION
Example usage:

```sh
smprofiler db sync-table \
    --table-name diagnosis \
    --database-config-file=~/.smprofiler_db.config.local \
    --study-json=generated_artifacts/study.json \
    --source-file=generated_artifacts/diagnosis.tsv
```

The script warns you to add `--drop-first` if you want to completely overwrite the existing records, otherwise it takes no action when existing records are found.