### PR TITLE
Persist one connection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smprofiler"
-version = "1.0.71"
+version = "1.0.72"
 authors = [
     { name = "James Mathews", email = "mathewj2@mskcc.org" }
 ]

--- a/requirements.apiserver.txt
+++ b/requirements.apiserver.txt
@@ -9,8 +9,8 @@ annsel==0.1.2
 anyio==4.13.0
 array-api-compat==1.14.0
 attrs==26.1.0
-boto3==1.42.87
-botocore==1.42.87
+boto3==1.42.89
+botocore==1.42.89
 brotli==1.2.0
 cattrs==26.1.0
 certifi==2026.2.25
@@ -81,8 +81,8 @@ psycopg2==2.9.11
 pyarrow==23.0.1
 pycparser==3.0
 pyct==0.6.0
-pydantic==2.12.5
-pydantic-core==2.41.5
+pydantic==2.13.0
+pydantic-core==2.46.0
 pygments==2.20.0
 pyjwt==2.12.1
 pymupdf==1.27.2.2
@@ -96,7 +96,7 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 rangehttpserver==1.4.0
 requests==2.33.1
-rich==14.3.3
+rich==15.0.0
 s3fs==0.4.2
 s3transfer==0.16.0
 scanpy==1.11.5
@@ -119,7 +119,7 @@ statsmodels==0.14.6
 tblib==3.2.2
 termplotlib==0.3.9
 threadpoolctl==3.6.0
-tifffile==2026.3.3
+tifffile==2026.4.11
 toolz==1.1.0
 tornado==6.5.5
 tqdm==4.67.3
@@ -130,7 +130,7 @@ universal-pathlib==0.3.10
 urllib3==2.6.3
 uvicorn==0.44.0
 wrapt==2.1.2
-xarray==2026.2.0
+xarray==2026.4.0
 xarray-dataclass==3.0.0
 xarray-spatial==0.9.6
 yarl==1.23.0

--- a/requirements.ondemand.txt
+++ b/requirements.ondemand.txt
@@ -81,8 +81,8 @@ psycopg==3.3.3
 psycopg2==2.9.11
 pyarrow==23.0.1
 pyct==0.6.0
-pydantic==2.12.5
-pydantic-core==2.41.5
+pydantic==2.13.0
+pydantic-core==2.46.0
 pygments==2.20.0
 pynndescent==0.6.0
 pyogrio==0.12.1
@@ -94,7 +94,7 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 rangehttpserver==1.4.0
 requests==2.33.1
-rich==14.3.3
+rich==15.0.0
 s3fs==2026.3.0
 s3transfer==0.16.0
 scanpy==1.11.5
@@ -117,7 +117,7 @@ tabulate==0.10.0
 tblib==3.2.2
 termplotlib==0.3.9
 threadpoolctl==3.6.0
-tifffile==2026.3.3
+tifffile==2026.4.11
 toolz==1.1.0
 tornado==6.5.5
 tqdm==4.67.3
@@ -129,7 +129,7 @@ universal-pathlib==0.3.10
 urllib3==2.6.3
 validators==0.35.0
 wrapt==2.1.2
-xarray==2026.2.0
+xarray==2026.4.0
 xarray-dataclass==3.0.0
 xarray-spatial==0.9.6
 yarl==1.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,8 +95,8 @@ py-cpuinfo==9.0.0
 pyarrow==23.0.1
 pycparser==3.0
 pyct==0.6.0
-pydantic==2.12.5
-pydantic-core==2.41.5
+pydantic==2.13.0
+pydantic-core==2.46.0
 pygments==2.20.0
 pyjwt==2.12.1
 pymupdf==1.27.2.2
@@ -110,7 +110,7 @@ pytz==2026.1.post1
 pyyaml==6.0.3
 rangehttpserver==1.4.0
 requests==2.33.1
-rich==14.3.3
+rich==15.0.0
 s3fs==2026.3.0
 s3transfer==0.16.0
 scanpy==1.11.5
@@ -137,7 +137,7 @@ tabulate==0.10.0
 tblib==3.2.2
 termplotlib==0.3.9
 threadpoolctl==3.6.0
-tifffile==2026.3.3
+tifffile==2026.4.11
 toolz==1.1.0
 tornado==6.5.5
 tqdm==4.67.3
@@ -150,7 +150,7 @@ urllib3==2.6.3
 uvicorn==0.44.0
 validators==0.35.0
 wrapt==2.1.2
-xarray==2026.2.0
+xarray==2026.4.0
 xarray-dataclass==3.0.0
 xarray-spatial==0.9.6
 xyzservices==2026.3.0

--- a/smprofiler/ondemand/cache_store.py
+++ b/smprofiler/ondemand/cache_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from atexit import register as register_at_exit
 from dataclasses import dataclass
 import os
 import re
@@ -10,9 +11,10 @@ from typing import Any
 
 from boto3 import client as boto3_client
 from botocore.exceptions import ClientError
+from psycopg import Connection as PsycopgConnection
 
 from smprofiler.db.database_connection import DBCursor
-
+from smprofiler.db.database_connection import DBConnection
 
 S3_CACHE_URI_ENV = "SMProfiler_S3_CACHE_URI"
 
@@ -54,8 +56,18 @@ class CacheStore(Protocol):
         ...
 
 class DatabaseCacheStore:
-    def __init__(self, database_config_file: str | None) -> None:
-        self.database_config_file = database_config_file
+    connection: DBConnection
+
+    def __init__(self, database_config_file: str | None, connection: DBConnection | None=None) -> None:
+        if connection is not None:
+            self.connection = connection
+        else:
+            self.connection = DBConnection(database_config_file=database_config_file)
+            self.connection.__enter__()
+        register_at_exit(self._cleanup)
+
+    def _cleanup(self) -> None:
+        self.connection.__exit__(None, None, None)
 
     def put_blob(
         self,
@@ -67,7 +79,7 @@ class DatabaseCacheStore:
         drop_first: bool = False,
     ) -> None:
         specimen = self._preprocess_handle(specimen)
-        with DBCursor(database_config_file=self.database_config_file, study=study) as cursor:
+        with DBCursor(connection=self.connection, study=study) as cursor:
             if drop_first:
                 drop = '''
                 DELETE FROM
@@ -88,7 +100,7 @@ class DatabaseCacheStore:
 
     def delete_blob(self, study: str | None, specimen: str | None, blob_type: str) -> None:
         specimen = self._preprocess_handle(specimen)
-        with DBCursor(database_config_file=self.database_config_file, study=study) as cursor:
+        with DBCursor(connection=self.connection, study=study) as cursor:
             delete_query = '''
                 DELETE FROM ondemand_studies_index
                 WHERE specimen=%s AND blob_type=%s ;
@@ -103,7 +115,7 @@ class DatabaseCacheStore:
         blob_type: str,
     ) -> bytes:
         specimen = self._preprocess_handle(specimen)
-        with DBCursor(database_config_file=self.database_config_file, study=study) as cursor:
+        with DBCursor(connection=self.connection, study=study) as cursor:
             select_query = '''
                 SELECT blob_contents FROM
                 ondemand_studies_index
@@ -117,7 +129,7 @@ class DatabaseCacheStore:
             return rows[0][0]
 
     def _get_valid_keys(self, study: str | None) -> tuple[Any, ...]:
-        with DBCursor(database_config_file=self.database_config_file, study=study) as cursor:
+        with DBCursor(connection=self.connection, study=study) as cursor:
             cursor.execute('SELECT specimen, blob_type FROM ondemand_studies_index;')
             return tuple(map(lambda row: (study, *row), tuple(cursor.fetchall())))
 
@@ -128,7 +140,7 @@ class DatabaseCacheStore:
         blob_type: str,
     ) -> bool:
         specimen = self._preprocess_handle(specimen)
-        with DBCursor(database_config_file=self.database_config_file, study=study) as cursor:
+        with DBCursor(connection=self.connection, study=study) as cursor:
             select_query = '''
                 SELECT COUNT(*) FROM
                 ondemand_studies_index


### PR DESCRIPTION
Persist once database connection for re-use during ETL. This was previously already implemented but the new cache store usage didn't replicate this.